### PR TITLE
Add Dex Enum

### DIFF
--- a/jup-ag-sdk/src/client/token_api.rs
+++ b/jup-ag-sdk/src/client/token_api.rs
@@ -4,8 +4,6 @@ use crate::{
     types::{NewTokens, TokenInfoResponse, TokenPriceRequest, TokenPriceResponse},
 };
 
-// TODO: examples for reccuring
-
 impl JupiterClient {
     /// Returns prices of specified tokens.
     /// ```

--- a/jup-ag-sdk/src/types/dex_enum.rs
+++ b/jup-ag-sdk/src/types/dex_enum.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize, Serializer};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DexEnum {
     Woofi,
     PumpFun,

--- a/jup-ag-sdk/src/types/dex_enum.rs
+++ b/jup-ag-sdk/src/types/dex_enum.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DexEnum {
+    Woofi,
+    PumpFun,
+    Whirlpool,
+    Virtuals,
+    DaosFun,
+    LifinityV2,
+    StabbleStableSwap,
+    TokenMill,
+    Meteora,
+    Oasis,
+    Aldrin,
+    GooseFxGamma,
+    Perps,
+    SolFi,
+    DexLab,
+    TokenSwap,
+    ZeroFi,
+    Cropper,
+    ObricV2,
+    StabbleWeightedSwap,
+    SanctumInfinity,
+    Moonit,
+    Sanctum,
+    RaydiumCp,
+    Phoenix,
+    PumpFunAmm,
+    Saber,
+    SaberDecimals,
+    RaydiumClmm,
+    Dex1,
+    Penguin,
+    OrcaV2,
+    FluxBeam,
+    Raydium,
+    MeteoraDlmm,
+    Bonkswap,
+    Solayer,
+    Stepn,
+    HeliumNetwork,
+    Mercurial,
+    Perena,
+    OrcaV1,
+    AldrinV2,
+    Saros,
+    OpenBookV2,
+    Crema,
+    OpenBook,
+    Invariant,
+    Guacswap,
+}
+
+impl std::fmt::Display for DexEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            DexEnum::Woofi => "Woofi",
+            DexEnum::PumpFun => "Pump.fun",
+            DexEnum::Whirlpool => "Whirlpool",
+            DexEnum::Virtuals => "Virtuals",
+            DexEnum::DaosFun => "Daos.fun",
+            DexEnum::LifinityV2 => "Lifinity V2",
+            DexEnum::StabbleStableSwap => "Stabble Stable Swap",
+            DexEnum::TokenMill => "Token Mill",
+            DexEnum::Meteora => "Meteora",
+            DexEnum::Oasis => "Oasis",
+            DexEnum::Aldrin => "Aldrin",
+            DexEnum::GooseFxGamma => "GooseFX GAMMA",
+            DexEnum::Perps => "Perps",
+            DexEnum::SolFi => "SolFi",
+            DexEnum::DexLab => "DexLab",
+            DexEnum::TokenSwap => "Token Swap",
+            DexEnum::ZeroFi => "ZeroFi",
+            DexEnum::Cropper => "Cropper",
+            DexEnum::ObricV2 => "Obric V2",
+            DexEnum::StabbleWeightedSwap => "Stabble Weighted Swap",
+            DexEnum::SanctumInfinity => "Sanctum Infinity",
+            DexEnum::Moonit => "Moonit",
+            DexEnum::Sanctum => "Sanctum",
+            DexEnum::RaydiumCp => "Raydium CP",
+            DexEnum::Phoenix => "Phoenix",
+            DexEnum::PumpFunAmm => "Pump.fun Amm",
+            DexEnum::Saber => "Saber",
+            DexEnum::SaberDecimals => "Saber (Decimals)",
+            DexEnum::RaydiumClmm => "Raydium CLMM",
+            DexEnum::Dex1 => "1DEX",
+            DexEnum::Penguin => "Penguin",
+            DexEnum::OrcaV2 => "Orca V2",
+            DexEnum::FluxBeam => "FluxBeam",
+            DexEnum::Raydium => "Raydium",
+            DexEnum::MeteoraDlmm => "Meteora DLMM",
+            DexEnum::Bonkswap => "Bonkswap",
+            DexEnum::Solayer => "Solayer",
+            DexEnum::Stepn => "StepN",
+            DexEnum::HeliumNetwork => "Helium Network",
+            DexEnum::Mercurial => "Mercurial",
+            DexEnum::Perena => "Perena",
+            DexEnum::OrcaV1 => "Orca V1",
+            DexEnum::AldrinV2 => "Aldrin V2",
+            DexEnum::Saros => "Saros",
+            DexEnum::OpenBookV2 => "OpenBook V2",
+            DexEnum::Crema => "Crema",
+            DexEnum::OpenBook => "Openbook",
+            DexEnum::Invariant => "Invariant",
+            DexEnum::Guacswap => "Guacswap",
+        };
+        write!(f, "{label}")
+    }
+}
+
+pub fn dex_vec_to_comma_string<S>(
+    vec: &Option<Vec<DexEnum>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match vec {
+        Some(v) => {
+            let joined = v
+                .iter()
+                .map(|dex| dex.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            serializer.serialize_str(&joined)
+        }
+        None => serializer.serialize_none(),
+    }
+}

--- a/jup-ag-sdk/src/types/mod.rs
+++ b/jup-ag-sdk/src/types/mod.rs
@@ -1,6 +1,9 @@
 pub mod quote_request;
 pub use quote_request::*;
 
+pub mod dex_enum;
+pub use dex_enum::*;
+
 pub mod quote_response;
 pub use quote_response::*;
 

--- a/jup-ag-sdk/src/types/quote_request.rs
+++ b/jup-ag-sdk/src/types/quote_request.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize, Serializer};
 
+use super::{DexEnum, dex_vec_to_comma_string};
+
 /// A request struct for fetching a quote from Jupiter's `/quote` endpoint.
 ///
 /// Use `QuoteRequest::new()` and the fluent setters to configure parameters.
@@ -44,14 +46,14 @@ pub struct QuoteRequest {
     /// Example: `["Orca", "Meteora+DLMM"]`
     /// TODO: add the list of dexes avaliable
     /// refer: https://github.com/Jupiter-DevRel/jup-ag-sdk/blob/main/jup_ag_sdk/models/common/dex_enum.py
-    #[serde(serialize_with = "vec_to_comma_string")]
-    pub dexes: Option<Vec<String>>,
+    #[serde(serialize_with = "dex_vec_to_comma_string")]
+    pub dexes: Option<Vec<DexEnum>>,
 
     /// A list of DEXes to exclude from routing.
     ///
     /// Example: `["Raydium", "Lifinity"]`
-    #[serde(serialize_with = "vec_to_comma_string")]
-    pub exclude_dexes: Option<Vec<String>>,
+    #[serde(serialize_with = "dex_vec_to_comma_string")]
+    pub exclude_dexes: Option<Vec<DexEnum>>,
 
     /// If true, restricts intermediate tokens to a stable set.
     ///
@@ -190,7 +192,7 @@ impl QuoteRequest {
     /// Only routes through these DEXes will be considered.
     ///
     /// # Arguments
-    /// * `dexes` - A vector of DEX names (e.g., `["Orca", "Meteora+DLMM"]`).
+    /// * `dexes` - A vector of DEX names (e.g., `["DexEnum::Orca", "DexEnum::MeteoraDlmm"]`).
     ///
     /// # Returns
     /// The modified `QuoteRequest` for chaining.
@@ -202,22 +204,20 @@ impl QuoteRequest {
     ///     "So11111111111111111111111111111111111111112",
     ///     "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
     ///     1_000_000_000
-    /// )
-    /// .dexes(vec!["Orca+V1".to_string(), "Meteora+DLMM".to_string()]);
-    /// assert_eq!(request.dexes, Some(vec!["Orca+V1`".to_string(), "Meteora+DLMM".to_string()]));
+    /// ).dexes(vec![DexEnum::MeteoraDlmm, DexEnum::Meteora]);
     /// ```
     /// [list of dexes](https://lite-api.jup.ag/swap/v1/program-id-to-label)
-    pub fn dexes(mut self, dexes: Vec<String>) -> Self {
+    pub fn dexes(mut self, dexes: Vec<DexEnum>) -> Self {
         self.dexes = Some(dexes);
         self
     }
 
-    /// Sets the list of DEXes to exclude from routing.
+    /// Sets the list of DEXes to exclude from routing. You can only specify one of `dexes` or `exclude_dexes` not both at the same time.
     ///
     /// Routes will avoid these DEXes.
     ///
     /// # Arguments
-    /// * `exclude_dexes` - A vector of DEX names to exclude (e.g., `["Raydium", "Lifinity"]`).
+    /// * `exclude_dexes` - A vector of DEX names to exclude (e.g., `[DexEnum::Raydium, DexEnum::OrcaV2]`).
     ///
     /// # Returns
     /// The modified `QuoteRequest` for chaining.
@@ -230,12 +230,10 @@ impl QuoteRequest {
     ///     "So11111111111111111111111111111111111111112",
     ///     "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
     ///     1_000_000_000
-    /// )
-    /// .exclude_dexes(vec!["Guacswap".to_string(), "Lifinity".to_string()]);
-    /// assert_eq!(request.exclude_dexes, Some(vec!["Guacswap".to_string(), "Lifinity".to_string()]));
+    /// ).exclude_dexes(vec![DexEnum::Raydium, DexEnum::OrcaV2]);
     /// ```
     /// [list of dexes](https://lite-api.jup.ag/swap/v1/program-id-to-label)
-    pub fn exclude_dexes(mut self, exclude_dexes: Vec<String>) -> Self {
+    pub fn exclude_dexes(mut self, exclude_dexes: Vec<DexEnum>) -> Self {
         self.exclude_dexes = Some(exclude_dexes);
         self
     }

--- a/jup-ag-sdk/src/types/quote_request.rs
+++ b/jup-ag-sdk/src/types/quote_request.rs
@@ -44,8 +44,6 @@ pub struct QuoteRequest {
     /// A list of DEXes to exclusively include in routing.
     ///
     /// Example: `["Orca", "Meteora+DLMM"]`
-    /// TODO: add the list of dexes avaliable
-    /// refer: https://github.com/Jupiter-DevRel/jup-ag-sdk/blob/main/jup_ag_sdk/models/common/dex_enum.py
     #[serde(serialize_with = "dex_vec_to_comma_string")]
     pub dexes: Option<Vec<DexEnum>>,
 

--- a/tests/src/swap.rs
+++ b/tests/src/swap.rs
@@ -2,7 +2,7 @@
 mod swap_tests {
     use jup_ag_sdk::{
         JupiterClient,
-        types::{QuoteGetSwapModeEnum, QuoteRequest, SwapRequest},
+        types::{DexEnum, QuoteGetSwapModeEnum, QuoteRequest, SwapRequest},
     };
 
     use crate::common::{
@@ -27,8 +27,8 @@ mod swap_tests {
         let request = QuoteRequest::new(SOL_MINT, JUP_MINT, TEST_AMOUNT)
             .slippage_bps(DEFAULT_SLIPPAGE_BPS)
             .swap_mode(QuoteGetSwapModeEnum::ExactOut)
-            .dexes(vec!["Orca".to_string(), "Meteora+DLMM".to_string()])
-            .exclude_dexes(vec!["Raydium".to_string()])
+            .dexes(vec![DexEnum::OrcaV1, DexEnum::MeteoraDlmm])
+            .exclude_dexes(vec![DexEnum::Raydium])
             .restrict_intermediate_tokens(false)
             .only_direct_routes(true)
             .as_legacy_transaction(false)
@@ -51,12 +51,12 @@ mod swap_tests {
 
         assert_eq!(
             request.dexes,
-            Some(vec!["Orca".to_string(), "Meteora+DLMM".to_string()]),
+            Some(vec![DexEnum::OrcaV1, DexEnum::MeteoraDlmm]),
             "dexes should match"
         );
         assert_eq!(
             request.exclude_dexes,
-            Some(vec!["Raydium".to_string()]),
+            Some(vec![DexEnum::Raydium]),
             "excluded dexes should match"
         );
 


### PR DESCRIPTION
Added a Dex Enum. 
The list of dex's included in enum if from this endpoint 
[link](https://lite-api.jup.ag/swap/v1/program-id-to-label).

This will make quote request easy to customize.

```rust
let  req = QuoteRequest::new(
        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
        "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
        10_000_000,
    )
    .dexes(vec![DexEnum::MeteoraDlmm, DexEnum::Meteora]);
```