### PR TITLE
fix ultra get_order deseralization error

### DIFF
--- a/jup-ag-sdk/src/types/ultra.rs
+++ b/jup-ag-sdk/src/types/ultra.rs
@@ -195,7 +195,7 @@ pub struct UltraOrderResponse {
 
     pub prioritization_fee_lamports: u64,
 
-    pub swap_type: SwapType,
+    pub swap_type: String,
 
     #[serde(default)]
     pub transaction: Option<String>,
@@ -220,15 +220,7 @@ pub struct UltraOrderResponse {
     pub platform_fee: Option<PlatformFee>,
 
     #[serde(default)]
-    pub expire_at: Option<u64>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "lowercase")]
-pub enum SwapType {
-    Aggregator,
-    Rfq,
-    Hashflow,
+    pub expire_at: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
The error is due to type mismatch in `UltraOrderResponse` Struct 
```rust
pub expire_at: Option<u64> 
///this is supposed to be 
pub expire_at: Option<String> 
 ```
and changed the  pub swap_type: SwapType to just String since there are new unknown Possible values