### PR TITLE
Add test job before publishing crate to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,18 +3,35 @@ name: Publish Crate
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   # Add this to allow manual triggering from GitHub UI
   workflow_dispatch:
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo code
+        uses: actions/checkout@v4
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Tests
+        run: cd tests && cargo test
+
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    needs: [test]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Get all history for tags
+          fetch-depth: 0 # Get all history for tags
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -37,4 +54,5 @@ jobs:
         uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}
-          path: './jup-ag-sdk'
+          path: "./jup-ag-sdk"
+


### PR DESCRIPTION
This PR adds a test job to the existing crate publishing workflow to ensure the code passes all tests before publishing