### PR TITLE
fix: PrioritizationFeeLamports struct 

### DIFF
--- a/jup-ag-sdk/src/types/swap_transaction.rs
+++ b/jup-ag-sdk/src/types/swap_transaction.rs
@@ -68,7 +68,7 @@ pub struct SwapRequest {
     /// When enabled, it estimates slippage and apply it in the swap transaction directly, overwriting the slippageBps parameter in the quote response.
     /// Used together with dynamicSlippage in /quote, otherwise the slippage used will be the one in the /quote's slippageBps
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dyanmic_slippage: Option<bool>,
+    pub dynamic_slippage: Option<bool>,
 
     /// To use an exact compute unit price to calculate priority fee
     /// computeUnitLimit (1400000) * computeUnitPriceMicroLamports
@@ -143,7 +143,7 @@ impl SwapRequest {
             destination_token_account: None,
             dynamic_compute_unit_limit: None,
             skip_user_account_rpc_calls: None,
-            dyanmic_slippage: None,
+            dynamic_slippage: None,
             compute_unit_price_micro_lamports: None,
             blockhash_slots_to_expiry: None,
             quote_response: quote,
@@ -245,8 +245,8 @@ impl SwapRequest {
     /// Enables dynamic slippage estimation.
     ///
     /// If enabled, slippage will be recalculated at swap-time instead of using a fixed value.
-    pub fn dyanmic_slippage(mut self, dynamic: bool) -> Self {
-        self.dyanmic_slippage = Some(dynamic);
+    pub fn dynamic_slippage(mut self, dynamic: bool) -> Self {
+        self.dynamic_slippage = Some(dynamic);
         self
     }
 

--- a/jup-ag-sdk/src/types/swap_transaction.rs
+++ b/jup-ag-sdk/src/types/swap_transaction.rs
@@ -81,6 +81,8 @@ pub struct SwapRequest {
     pub quote_response: QuoteResponse,
 }
 
+/// Only one of these fields should be set at a time.
+/// Use either `jito_tip_lamports` or `priority_level_with_max_lamports`, not both.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrioritizationFeeLamports {
@@ -187,9 +189,6 @@ impl SwapRequest {
     }
 
     /// Set prioritization fee lamports
-    ///
-    /// Note:
-    /// - Cannot be combined with `priority_level_with_max_lamports`.
     pub fn prioritization_fee_jito_tip(mut self, fee: u64) -> Self {
         self.prioritization_fee_lamports = Some(PrioritizationFeeLamports {
             jito_tip_lamports: Some(fee),
@@ -203,9 +202,6 @@ impl SwapRequest {
     /// Allows specifying both:
     /// - Priority level (e.g., `medium`, `high`)
     /// - Maximum cap on lamports paid
-    ///
-    /// Note:
-    /// - Cannot be combined with `jito_tip_lamports`.
     pub fn prioritization_fee_config(
         mut self,
         max_lamports: u32,

--- a/jup-ag-sdk/src/types/swap_transaction.rs
+++ b/jup-ag-sdk/src/types/swap_transaction.rs
@@ -84,8 +84,11 @@ pub struct SwapRequest {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrioritizationFeeLamports {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub jito_tip_lamports: Option<u64>,
-    pub priority_level_with_max_lamports: PriorityLevelWithMaxLamports,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority_level_with_max_lamports: Option<PriorityLevelWithMaxLamports>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -184,30 +187,36 @@ impl SwapRequest {
     }
 
     /// Set prioritization fee lamports
+    ///
+    /// Note:
+    /// - Cannot be combined with `priority_level_with_max_lamports`.
     pub fn prioritization_fee_jito_tip(mut self, fee: u64) -> Self {
         self.prioritization_fee_lamports = Some(PrioritizationFeeLamports {
             jito_tip_lamports: Some(fee),
-            priority_level_with_max_lamports: PriorityLevelWithMaxLamports {
-                max_lamports: 0,
-                priority_level: PriorityLevel::Medium,
-            },
+            priority_level_with_max_lamports: None,
         });
         self
     }
 
-    /// set prioritization config
+    /// Sets a priority fee configuration based on estimated network congestion
+    ///
+    /// Allows specifying both:
+    /// - Priority level (e.g., `medium`, `high`)
+    /// - Maximum cap on lamports paid
+    ///
+    /// Note:
+    /// - Cannot be combined with `jito_tip_lamports`.
     pub fn prioritization_fee_config(
         mut self,
-        jito_tip: Option<u64>,
         max_lamports: u32,
         priority_level: PriorityLevel,
     ) -> Self {
         self.prioritization_fee_lamports = Some(PrioritizationFeeLamports {
-            jito_tip_lamports: jito_tip,
-            priority_level_with_max_lamports: PriorityLevelWithMaxLamports {
+            jito_tip_lamports: None,
+            priority_level_with_max_lamports: Some(PriorityLevelWithMaxLamports {
                 max_lamports,
                 priority_level,
-            },
+            }),
         });
         self
     }


### PR DESCRIPTION
- fix dynamic typo 
- fix the PrioritizationFeeLamports struct 
- swap endpoints expect only one of `jito_tip_lamports` or `priority_level_with_max_lamports`